### PR TITLE
Remove tumor restriction on valid samples

### DIFF
--- a/cglims/config.py
+++ b/cglims/config.py
@@ -20,7 +20,6 @@ def relevant_samples(lims_samples):
     """Filter out relevant samples for analysis."""
     included = (lims_sample for lims_sample in lims_samples
                 if (lims_sample.udf.get('cancelled') != 'yes' and
-                    lims_sample.udf.get('tumor') != 'yes' and
                     lims_sample.udf.get('exclude analysis') != 'yes'))
     return included
 


### PR DESCRIPTION
title says it all :)

A valid sample is now also a tumor sample.

What does this affect?
Valid samples will be eligible for delivery, now tumor samples' fastq files are not automatically linked.